### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,7 @@
 
 const pluginName = 'gulp-xv-webp-html'
 
-const gutil = require('gulp-util')
-const PluginError = gutil.PluginError
+const PluginError = require('plugin-error');
 
 const through = require('through2')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "gulp-xv-webp-html",
+  "version": "1.1.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gulp-xv-webp-html",
+      "version": "1.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "plugin-error": "^2.0.1",
+        "through2": "^4.0.2"
+      }
+    },
+    "../../../../node_modules/.pnpm/through2@4.0.2/node_modules/through2": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      },
+      "devDependencies": {
+        "bl": "^4.0.2",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "hundreds": "~0.0.7",
+        "mocha": "^7.2.0",
+        "polendina": "^1.0.0",
+        "standard": "^14.3.4",
+        "stream-spigot": "^3.0.6"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-wrap": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/plugin-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
+      "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/through2": {
+      "resolved": "../../../../node_modules/.pnpm/through2@4.0.2/node_modules/through2",
+      "link": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "homepage": "https://github.com/xvoland/gulp-xv-webp-html",
   "dependencies": {
-    "plugin-error": "^1.0.0",
+    "plugin-error": "^2.0.1",
     "through2": "^4.0.2"
   }
 }


### PR DESCRIPTION
This replaces the deprecated gutil.PluginError with the modern drop-in replacement plugin-error package.